### PR TITLE
0.0.3: Add BlinkaClient configuration for commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2021-02-02
+
+### Added
+
+- Allow supplying which git commit sha to report.
+
 ## [0.0.2] - 2021-02-01
 
 ### Added

--- a/blinka_reporter.gemspec
+++ b/blinka_reporter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name = 'blinka-reporter'
-  spec.version = '0.0.2'
-  spec.date = '2021-02-01'
+  spec.version = '0.0.3'
+  spec.date = '2021-02-02'
   spec.summary = 'Format tests for Blinka'
   spec.description =
     'Use to format test results from Minitest to use with Blinka.'

--- a/lib/blinka_client.rb
+++ b/lib/blinka_client.rb
@@ -18,7 +18,7 @@ class BlinkaClient
       @team_secret = ENV.fetch('BLINKA_TEAM_SECRET')
       @repository = ENV.fetch('BLINKA_REPOSITORY')
       @branch = ENV.fetch('BLINKA_BRANCH')
-      @commit = `git rev-parse HEAD`.chomp
+      @commit = ENV.fetch('BLINKA_COMMIT', `git rev-parse HEAD`.chomp)
     end
   end
 


### PR DESCRIPTION
- Adds the BLINKA_COMMIT environment variable which fallbacks to
  `git rev-parse HEAD`.
