### PR TITLE
0.2.1: Raise error if configuration is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2021-02-08
+
+### Changed
+
+- Raise error if configuration to report to Blinka is missing when reporting.
+
 ## [0.2.0] - 2021-02-07
 
 ### Added
@@ -51,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle inconsistency in source_location of test result in Minitest for different versions.
 
-[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/davidwessman/blinka_reporter/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/davidwessman/blinka_reporter/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/davidwessman/blinka_reporter/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/davidwessman/blinka_reporter/compare/v0.0.3...v0.1.0

--- a/blinka_reporter.gemspec
+++ b/blinka_reporter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name = 'blinka-reporter'
-  spec.version = '0.2.0'
-  spec.date = '2021-02-07'
+  spec.version = '0.2.1'
+  spec.date = '2021-02-08'
   spec.summary = 'Format tests for Blinka'
   spec.description =
     'Use to format test results from Minitest to use with Blinka.'

--- a/lib/blinka_client.rb
+++ b/lib/blinka_client.rb
@@ -13,12 +13,21 @@ class BlinkaClient
       :jwt_token
     )
     def initialize
-      @host = ENV.fetch('BLINKA_HOST', 'https://blinkblink.herokuapp.com')
-      @team_id = ENV.fetch('BLINKA_TEAM_ID')
-      @team_secret = ENV.fetch('BLINKA_TEAM_SECRET')
-      @repository = ENV.fetch('BLINKA_REPOSITORY')
+      @host = ENV.fetch('BLINKA_HOST', 'https://www.blinka.app')
+      @team_id = ENV.fetch('BLINKA_TEAM_ID', nil)
+      @team_secret = ENV.fetch('BLINKA_TEAM_SECRET', nil)
+      @repository = ENV.fetch('BLINKA_REPOSITORY', nil)
       @tag = ENV.fetch('BLINKA_TAG', '')
       @commit = ENV.fetch('BLINKA_COMMIT', `git rev-parse HEAD`.chomp)
+
+      if @team_id.nil? || @team_secret.nil? || @repository.nil?
+        raise(BlinkaError, <<~EOS)
+          Missing configuration, make sure to set required environment variables:
+          - BLINKA_TEAM_ID
+          - BLINKA_TEAM_SECRET
+          - BLINKA_REPOSITORY
+          EOS
+      end
     end
   end
 


### PR DESCRIPTION
- Require configuration to run reporting instead of failing because
authentication fails.
