### PR TITLE
[0.3.2] Allow running reports with Webmock enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2021-02-12
+
+### Fixed
+
+- Allow to report with `BLINKA_REPORT` while using in tests `WebMock`.
+
 ## [0.3.1] - 2021-02-12
 
 ### Added
@@ -69,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle inconsistency in source_location of test result in Minitest for different versions.
 
-[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.1...HEAD
+[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/davidwessman/blinka_reporter/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/davidwessman/blinka_reporter/compare/v0.2.0...v0.2.1

--- a/blinka_reporter.gemspec
+++ b/blinka_reporter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'blinka-reporter'
-  spec.version = '0.3.1'
+  spec.version = '0.3.2'
   spec.date = '2021-02-12'
   spec.summary = 'Format tests for Blinka'
   spec.description =
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('minitest', '~> 5.0')
   spec.add_development_dependency('mocha', '~> 1.12')
   spec.add_development_dependency('rake', '~> 13')
+  spec.add_development_dependency('webmock', '~> 3.11')
 end

--- a/test/example_results.json
+++ b/test/example_results.json
@@ -1,0 +1,113 @@
+{
+  "total_time": null,
+  "nbr_tests": 15,
+  "nbr_assertions": 20,
+  "seed": 38498,
+  "results": [
+    {
+      "kind": "general",
+      "name": "test_with_webmock_enabled",
+      "path": "test/test_blinka_client.rb",
+      "result": "pass",
+      "time": 4.400001489557326e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_image",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 0.00041199999395757914
+    },
+    {
+      "kind": "general",
+      "name": "test_image_no_file",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 0.0002080000122077763
+    },
+    {
+      "kind": "general",
+      "name": "test_kind_no_folder",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 4.499999340623617e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_report_with_image",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 0.00023200002033263445
+    },
+    {
+      "kind": "general",
+      "name": "test_message_no_failure",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 1.1999974958598614e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_backtrace_no_failure",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 9.99998883344233e-6
+    },
+    {
+      "kind": "general",
+      "name": "test_result",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 1.7999991541728377e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_message",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 1.09999964479357e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_backtrace",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 2.400000812485814e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_source_location",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 4.600000102072954e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_kind",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 3.7999998312443495e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_line_no_failure",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 9.000010322779417e-6
+    },
+    {
+      "kind": "general",
+      "name": "test_report",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 5.8999983593821526e-5
+    },
+    {
+      "kind": "general",
+      "name": "test_line",
+      "path": "test/test_blinka_minitest.rb",
+      "result": "pass",
+      "time": 7.000000914558768e-5
+    }
+  ]
+}

--- a/test/test_blinka_client.rb
+++ b/test/test_blinka_client.rb
@@ -1,0 +1,32 @@
+require 'minitest/autorun'
+require 'mocha/minitest'
+require 'webmock/minitest'
+
+require 'blinka_client'
+
+class BlinkaClientTest < Minitest::Test
+  def setup
+    # We must allow webmock to stay enabled, even if we need to disable it in the client.
+    ENV['BLINKA_ALLOW_WEBMOCK_DISABLE'] = 'false'
+    WebMock.disable_net_connect!
+  end
+
+  def teardown
+    ENV['BLINKA_ALLOW_WEBMOCK_DISABLE'] = 'true'
+  end
+
+  def test_report_class_method
+    stub_client
+    BlinkaClient.report(filepath: 'test/example_results.json')
+  end
+
+  def stub_client
+    WebMock
+      .stub_request(
+        :post,
+        "#{BlinkaClient::DEFAULT_HOST}/api/v1/authentication"
+      )
+      .to_return(body: { auth_token: 'auth-token' }.to_json)
+    WebMock.stub_request(:post, "#{BlinkaClient::DEFAULT_HOST}/api/v1/report")
+  end
+end


### PR DESCRIPTION
- Configuring WebMock in your tests collides with reporting using
`BLINKA_REPORT=true`.
