### PR TITLE
[0.3.3] Get commit from Heroku CI environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2021-02-13
+
+### Added
+
+- Use `HEROKU_TEST_RUN_COMMIT_VERSION` defined on Heroku CI when reporting test results to Blinka.
+
 ## [0.3.2] - 2021-02-12
 
 ### Fixed
@@ -75,7 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle inconsistency in source_location of test result in Minitest for different versions.
 
-[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.2...HEAD
+[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/davidwessman/blinka_reporter/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/davidwessman/blinka_reporter/compare/v0.2.1...v0.3.0

--- a/blinka_reporter.gemspec
+++ b/blinka_reporter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name = 'blinka-reporter'
-  spec.version = '0.3.2'
-  spec.date = '2021-02-12'
+  spec.version = '0.3.3'
+  spec.date = '2021-02-13'
   spec.summary = 'Format tests for Blinka'
   spec.description =
     'Use to format test results from Minitest to use with Blinka.'

--- a/lib/blinka_client.rb
+++ b/lib/blinka_client.rb
@@ -23,7 +23,7 @@ class BlinkaClient
       @team_secret = ENV.fetch('BLINKA_TEAM_SECRET', nil)
       @repository = ENV.fetch('BLINKA_REPOSITORY', nil)
       @tag = ENV.fetch('BLINKA_TAG', '')
-      @commit = ENV.fetch('BLINKA_COMMIT', `git rev-parse HEAD`.chomp)
+      @commit = BlinkaClient.find_commit
 
       if @team_id.nil? || @team_secret.nil? || @repository.nil?
         raise(BlinkaError, <<~EOS)
@@ -197,5 +197,12 @@ class BlinkaClient
         "mime_type": presigned_post.dig('fields', 'Content-Type')
       }
     }
+  end
+
+  def self.find_commit
+    ENV.fetch(
+      'BLINKA_COMMIT',
+      ENV.fetch('HEROKU_TEST_RUN_COMMIT_VERSION', `git rev-parse HEAD`.chomp)
+    )
   end
 end


### PR DESCRIPTION
- On Heroku CI there is no git-information available,
  instead use the local value HEROKU_TEST_RUN_COMMIT_VERSION.
