### PR TITLE
0.7.0: Adds support for reporting multiple files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1"]
 
@@ -29,7 +30,7 @@ jobs:
 
       - name: Run tests
         env:
-          BLINKA_JSON: true
+          BLINKA_PATH: ./results.json
         run: bundle exec rake test
 
       - name: Build and install gem
@@ -38,9 +39,12 @@ jobs:
 
       - name: Report to Blinka
         if: always()
-        env:
-          BLINKA_REPOSITORY: davidwessman/blinka_reporter
-          BLINKA_TEAM_ID: ${{ secrets.BLINKA_TEAM_ID }}
-          BLINKA_TEAM_SECRET: ${{ secrets.BLINKA_TEAM_SECRET }}
-          BLINKA_TAG: ${{ matrix.ruby }}
-        run: blinka_reporter --blinka --tap --path ./blinka_results.json
+        run: |
+          blinka_reporter \
+          --blinka \
+          --tap \
+          --path ./results.json \
+          --repository davidwessman/blinka_reporter \
+          --tag ${{ matrix.ruby }} \
+          --team-id ${{ secrets.BLINKA_TEAM_ID }} \
+          --team-secret ${{ secrets.BLINKA_TEAM_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 .yarn-integrity
 
 /blinka_results.json
+/results.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2022-03-06
+
+- Support multiple `--path` calls to combine results from multiple files.
+- Replaces `BLINKA_JSON` and `BLINKA_APPEND` with `BLINKA_PATH`.
+- Adds all reporter options as CLI-options instead of using environment variables. -`BLINKA_REPOSITORY` => `--repository`
+
 ## [0.6.1] - 2022-02-27
 
 - Rspec
@@ -137,7 +143,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle inconsistency in source_location of test result in Minitest for different versions.
 
-[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.6.1...HEAD
+[unreleased]: https://github.com/davidwessman/blinka_reporter/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/davidwessman/blinka_reporter/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/davidwessman/blinka_reporter/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/davidwessman/blinka_reporter/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/davidwessman/blinka_reporter/compare/v0.5.1...v0.5.2

--- a/lib/blinka_reporter/blinka.rb
+++ b/lib/blinka_reporter/blinka.rb
@@ -99,7 +99,10 @@ module BlinkaReporter
       when 200
         @jwt_token = JSON.parse(response.body).dig('auth_token')
       else
-        raise(BlinkaReporter::Error, 'Could not authenticate to API')
+        raise(
+          BlinkaReporter::Error,
+          "Could not authenticate to API #{response.code}"
+        )
       end
     end
 

--- a/lib/blinka_reporter/cli.rb
+++ b/lib/blinka_reporter/cli.rb
@@ -9,28 +9,58 @@ module BlinkaReporter
           blinka_reporter version #{BlinkaReporter::VERSION}
 
           Options:
-          --tap: Flag for outputting test results in TAP-protocol, helpful on Heroku CI.
-          --blinka: Flag for reporting test results to blinka.app, requires setting environment:
-                    - BLINKA_TEAM_ID
-                    - BLINKA_TEAM_SECRET
-                    - BLINKA_REPOSITORY
-          --path <path>: Path to test results file, works for
-                  - ./blinka_results.json blinka json format [default]
-                  - ./rspec.xml from https://github.com/sj26/rspec_junit_formatter
+          --path <path>: Path to test results file, can be supplied multiple times to combine results
+            - ./blinka_results.json blinka json format
+            - ./rspec.xml from https://github.com/sj26/rspec_junit_formatter
+
+          --tap: Flag for outputting test results in TAP-protocol, helpful on Heroku CI
+          --blinka: Flag for reporting test results to blinka.app, requires also supplying:
+            - --team-id
+            - --team-secret
+            - --repository
+            - --commit
+          --team-id <team-id>: Blinka team id, only used with --blinka
+          --team-secret <team-secret>: Blinka team secret, only used with --blinka
+          --commit <commit>: The commit hash to report
+          --tag <tag>: The tag for the run, for example to separate a test matrix
+          --repository <repository>: The Github repository
+          --host <host>: Override Blink host to send report
+
         EOS
         return 0
       end
 
       tap = (argv.index('--tap') || -1) >= 0
+
+      paths = argv_value_for(argv, '--path')
+
       blinka = (argv.index('--blinka') || -1) >= 0
-      path = argv_value_for(argv, '--path') || './blinka_results.json'
-      BlinkaReporter::Client.report(blinka: blinka, tap: tap, path: path)
-      0
+      commit = argv_value_for(argv, '--commit')&.first
+      repository = argv_value_for(argv, '--repository')&.first
+      tag = argv_value_for(argv, '--tag')&.first
+      team_id = argv_value_for(argv, '--team-id')&.first
+      team_secret = argv_value_for(argv, '--team-secret')&.first
+      host = argv_value_for(argv, '--host')&.first
+
+      client = BlinkaReporter::Client.new
+      data = client.parse(paths: paths)
+      config =
+        BlinkaReporter::Config.new(
+          tag: tag,
+          commit: commit,
+          team_id: team_id,
+          team_secret: team_secret,
+          repository: repository,
+          host: host
+        )
+      client.report(data: data, config: config, tap: tap, blinka: blinka)
     end
 
     def self.argv_value_for(argv, option_name)
-      return unless (index = argv.index(option_name))
-      argv[index + 1]
+      argv
+        .each_index
+        .select { |index| argv[index] == option_name }
+        .map { |index| argv[index + 1] }
     end
   end
 end

--- a/lib/blinka_reporter/config.rb
+++ b/lib/blinka_reporter/config.rb
@@ -3,32 +3,35 @@ require 'blinka_reporter/error'
 module BlinkaReporter
   class Config
     attr_reader(:commit, :host, :repository, :tag, :team_id, :team_secret)
+    DEFAULT_HOST = 'https://www.blinka.app'
 
-    def initialize
-      @commit = find_commit
-      @host = ENV.fetch('BLINKA_HOST', 'https://www.blinka.app')
-      @repository = ENV.fetch('BLINKA_REPOSITORY', nil)
-      @tag = ENV.fetch('BLINKA_TAG', nil)
-      @team_id = ENV.fetch('BLINKA_TEAM_ID', nil)
-      @team_secret = ENV.fetch('BLINKA_TEAM_SECRET', nil)
+    def initialize(
+      tag:,
+      commit:,
+      repository:,
+      host: nil,
+      team_id:,
+      team_secret:
+    )
+      @commit = commit || find_commit
+      @host = host || DEFAULT_HOST
+      @repository = repository
+      @tag = tag
+      @team_id = team_id
+      @team_secret = team_secret
     end
 
     def validate_blinka
-      if @team_id.nil? || @team_secret.nil? || @repository.nil?
+      required = [@team_id, @team_secret, @repository]
+      if required.include?(nil) || required.include?('')
         raise(BlinkaReporter::Error, <<~EOS)
-          Missing configuration, make sure to set required environment variables:
-          - BLINKA_TEAM_ID
-          - BLINKA_TEAM_SECRET
-          - BLINKA_REPOSITORY
-          EOS
+          Missing configuration, make sure to set --team-id, --team-secret, --repository
+        EOS
       end
     end
 
     def find_commit
-      ENV.fetch(
-        'BLINKA_COMMIT',
-        ENV.fetch('HEROKU_TEST_RUN_COMMIT_VERSION', `git rev-parse HEAD`.chomp)
-      )
+      ENV.fetch('HEROKU_TEST_RUN_COMMIT_VERSION', `git rev-parse HEAD`.chomp)
     end
   end
 end

--- a/lib/minitest/blinka_plugin.rb
+++ b/lib/minitest/blinka_plugin.rb
@@ -11,31 +11,29 @@ module Minitest
   def plugin_blinka_options(opts, options); end
 
   module BlinkaPlugin
-    REPORT_PATH = 'blinka_results.json'.freeze
     class Reporter < Minitest::StatisticsReporter
       attr_accessor :tests
 
-      def initialize(io = $stdout, options = {})
-        super
-        self.tests = []
-      end
-
       def record(test)
         super
+        self.tests ||= []
         tests << test
       end
 
       def report
         super
 
-        json_report(append: !ENV['BLINKA_APPEND'].nil?) if ENV['BLINKA_JSON']
-      rescue BlinkaReporter::Client::BlinkaReporter::Error => error
+        json_report
+      rescue BlinkaReporter::Error => error
         puts(error)
       end
 
       private
 
-      def json_report(append:)
+      def json_report
+        report_path = ENV['BLINKA_PATH']
+        return if report_path.nil? || report_path.eql?('')
+
         result = {
           total_time: total_time,
           nbr_tests: count,
@@ -46,34 +44,13 @@ module Minitest
               BlinkaReporter::MinitestAdapter.new(test_result).report
             end
         }
-        result = append_previous(result) if append
 
-        File.open(REPORT_PATH, 'w+') do |file|
+        File.open(report_path, 'w+') do |file|
           file.write(JSON.pretty_generate(result))
         end
 
         puts
-        puts("Test results written to `#{REPORT_PATH}`")
-      end
-
-      private
-
-      def parse_report
-        return unless File.exist?(REPORT_PATH)
-        JSON.parse(File.read(REPORT_PATH), symbolize_names: true)
-      end
-
-      def append_previous(result)
-        previous = parse_report
-        return if previous.nil?
-        return if result[:commit] != previous[:commit]
-        return if result[:tag] != previous[:tag]
-
-        result[:total_time] += previous[:total_time] || 0
-        result[:nbr_tests] += previous[:nbr_tests] || 0
-        result[:nbr_assertions] += previous[:nbr_assertions] || 0
-        result[:results] += previous[:results] || []
-        result
+        puts("Test results written to `#{report_path}`")
       end
     end
   end

--- a/test/test_parsing.rb
+++ b/test/test_parsing.rb
@@ -5,7 +5,7 @@ require 'blinka_reporter/client'
 
 class BlinkaParsingTest < Minitest::Test
   def test_parse_xml
-    data = BlinkaReporter::Client.parse_xml(path: 'test/rspec.xml')
+    data = BlinkaReporter::Client.new.parse(paths: 'test/rspec.xml')
 
     assert_equal(54, data[:results].size)
 
@@ -20,5 +20,38 @@ class BlinkaParsingTest < Minitest::Test
     assert_equal('fail', last_failure[:result])
     assert_equal(9, last_failure[:backtrace].size)
     refute_nil(last_failure[:image])
+  end
+
+  def test_parse_json
+    data = BlinkaReporter::Client.new.parse(paths: 'test/blinka_results.json')
+
+    assert_equal(75, data[:results].size)
+
+    error = data[:results][73]
+    refute_nil(error)
+    assert_equal('error', error[:result])
+    assert_equal(2, error[:backtrace].size)
+    refute_nil(error[:image])
+
+    failure = data[:results][74]
+    refute_nil(failure)
+    assert_equal('fail', failure[:result])
+    assert_equal(1, failure[:backtrace].size)
+    refute_nil(failure[:image])
+  end
+
+  def test_combining_results
+    data =
+      BlinkaReporter::Client.new.parse(
+        paths: %w[test/rspec.xml test/blinka_results.json]
+      )
+
+    assert_equal(54 + 75, data[:results].size)
+
+    specs = data[:results].count { |result| result[:path].include?('spec/') }
+    tests = data[:results].count { |result| result[:path].include?('test/') }
+
+    assert_equal(54, specs)
+    assert_equal(75, tests)
   end
 end


### PR DESCRIPTION
- Support multiple `--path` calls to combine results from multiple files.
- Replaces `BLINKA_JSON` and `BLINKA_APPEND` with `BLINKA_PATH`.
- Adds all reporter options as CLI-options instead of using
  environment variables. 
  - `BLINKA_REPOSITORY` => `--repository`
